### PR TITLE
Added the ability to set the gutter object itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Split(<HTMLElement|selector[]> elements, <options> options?)
 | sizes | Array | | Initial sizes of each element in percents or CSS values. |
 | minSize | Number or Array | 100 | Minimum size of each element. |
 | gutterSize | Number | 10 | Gutter size in pixels. |
+| gutterElem | DOM Element | | Specify a DOM Element to act as the gutter. |
 | snapOffset | Number | 30 | Snap to minimum width offset in pixels. |
 | direction | String | 'horizontal' | Direction to split: horizontal or vertical. |
 | cursor | String | 'col-resize' | Cursor to display while dragging. |
@@ -77,6 +78,14 @@ Specifying the initial widths with CSS values. Not recommended, the size/gutter 
 ```js
 Split(['#one', '#two'], {
 	sizes: ['200px', '500px']
+});
+```
+
+Create your own gutter style and specify it to act as the gutter.
+
+```js
+Split(['#one', '#two'], {
+    gutterElem: document.getElementById('#MyGutterID');
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Split(['#one', '#two'], {
 });
 ```
 
-Create your own gutter style and specify it to act as the gutter.
+Create your own gutter element and specify it to act as the gutter.
 
 ```js
 Split(['#one', '#two'], {

--- a/index.html
+++ b/index.html
@@ -133,6 +133,12 @@
                     <td>10</td>
                     <td>Gutter size in pixels.</td>
                   </tr>
+				  <tr>
+                    <td>gutterElem</td>
+                    <td>DOM Element</td>
+                    <td></td>
+                    <td>Specify a DOM Element to act as the gutter.</td>
+                  </tr>
                   <tr>
                     <td>snapOffset</td>
                     <td>Number</td>

--- a/index.html
+++ b/index.html
@@ -133,7 +133,7 @@
                     <td>10</td>
                     <td>Gutter size in pixels.</td>
                   </tr>
-				  <tr>
+		  <tr>
                     <td>gutterElem</td>
                     <td>DOM Element</td>
                     <td></td>

--- a/split.js
+++ b/split.js
@@ -298,15 +298,19 @@ var global = this
         // IE9 and above
         if (!isIE8) {
             if (i > 0) {
-                var gutter = document.createElement('div')
+                var gutter;
+                if (typeof(options.gutterObj) === 'undefined') {
+                    gutter = document.createElement('div')
 
-                gutter.className = gutterClass
-                gutter.style[dimension] = options.gutterSize + 'px'
-
+                    gutter.className = gutterClass
+                    gutter.style[dimension] = options.gutterSize + 'px'
+                    parent.insertBefore(gutter, el)
+                } else {
+                    gutter = options.gutterObj
+                }
                 gutter[addEventListener]('mousedown', startDragging.bind(pair))
                 gutter[addEventListener]('touchstart', startDragging.bind(pair))
 
-                parent.insertBefore(gutter, el)
 
                 pair.gutter = gutter
             }

--- a/split.js
+++ b/split.js
@@ -300,9 +300,7 @@ var global = this
             if (i > 0) {
                 var gutter
 				
-				
                 if (typeof(options.gutterObj) === 'undefined') {
-					//Create Gutter if obj is not set
                     gutter = document.createElement('div')
 
                     gutter.className = gutterClass
@@ -311,9 +309,9 @@ var global = this
                 } else {
                     gutter = options.gutterObj
                 }
+				
                 gutter[addEventListener]('mousedown', startDragging.bind(pair))
                 gutter[addEventListener]('touchstart', startDragging.bind(pair))
-
 
                 pair.gutter = gutter
             }

--- a/split.js
+++ b/split.js
@@ -300,14 +300,14 @@ var global = this
             if (i > 0) {
                 var gutter
 				
-                if (typeof(options.gutterObj) === 'undefined') {
+                if (typeof(options.gutterElem) === 'undefined') {
                     gutter = document.createElement('div')
 
                     gutter.className = gutterClass
                     gutter.style[dimension] = options.gutterSize + 'px'
                     parent.insertBefore(gutter, el)
                 } else {
-                    gutter = options.gutterObj
+                    gutter = options.gutterElem 
                 }
 				
                 gutter[addEventListener]('mousedown', startDragging.bind(pair))

--- a/split.js
+++ b/split.js
@@ -298,8 +298,11 @@ var global = this
         // IE9 and above
         if (!isIE8) {
             if (i > 0) {
-                var gutter;
+                var gutter
+				
+				
                 if (typeof(options.gutterObj) === 'undefined') {
+					//Create Gutter if obj is not set
                     gutter = document.createElement('div')
 
                     gutter.className = gutterClass


### PR DESCRIPTION
Hi,

I loved your implementation of the splitter but I felt the gutter customization was abit lacking. So, I added the ability for users to set the gutter object itself.

The use case here is to allow people to set a completely custom html object as their gutter.
Users will simply need to add this to their options...

`gutterObj: document.getElementById("<GUTTERIDHERE>"),`

and be able to select any html object to act as their gutter. Allowing people to create unique gutter styles.
