### PR TITLE
added boolean to destroy method to optionally preserve sizes

### DIFF
--- a/split.js
+++ b/split.js
@@ -488,11 +488,16 @@ var Split = function (ids, options) {
         });
     }
 
-    function destroy () {
+    function destroy (preserve) {
         pairs.forEach(function (pair) {
-            pair.parent.removeChild(pair.gutter);
-            elements[pair.a].element.style[dimension] = '';
-            elements[pair.b].element.style[dimension] = '';
+            if (preserve === true) {
+                pair.parent.removeChild(pair.gutter);
+                elements[pair.a].element.style[dimension] = elements[pair.a].size + '%';
+            } else {
+                pair.parent.removeChild(pair.gutter);
+                elements[pair.a].element.style[dimension] = '';
+                elements[pair.b].element.style[dimension] = '';
+            }
         });
     }
 


### PR DESCRIPTION
When destroying the splitter, have an option to preserve the pane sizes. Throw away the gutters, but retain the percentages by copying them to the appropriate style property.