### PR TITLE
replace yarn install with yarn add

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 Yarn:
 
 ```
-$ yarn install --save split.js
+$ yarn add split.js
 ```
 
 npm:


### PR DESCRIPTION
`install` has been replaced with `add` to add new dependencies.