### PR TITLE
update README.md (fix yarn install syntax)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 Yarn:
 
 ```
-$ yarn install --save split.js
+$ yarn add split.js
 ```
 
 npm:


### PR DESCRIPTION
updates installation instructions to reflect updated yarn command. i.e. `yarn add ...` rather than `yarn install --save ...`