### PR TITLE
Resizing stalls if the mouse leaves the container

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,5 +19,6 @@
     "quote-props": ["error", "consistent"],
     "space-before-function-paren": ["error", { "anonymous": "never", "named": "always" }],
     "arrow-parens": [2, "as-needed", { "requireForBlockBody": false }],
+    "no-param-reassign": ["error", { "props": false }],
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "homepage": "https://github.com/nathancahill/Split.js#readme",
   "devDependencies": {
     "buble": "^0.15.2",
-    "eslint": "^3.14.1",
+    "eslint": "^3.19.0",
     "eslint-config-airbnb": "^14.0.0",
     "eslint-plugin-compat": "^1.0.2",
     "eslint-plugin-import": "^2.2.0",

--- a/src/split.js
+++ b/src/split.js
@@ -72,11 +72,8 @@ const elementOrSelector = el => {
 // 5. Actually size the pair elements, insert gutters and attach event listeners.
 const Split = (ids, options = {}) => {
     let dimension
-    let clientDimension
     let clientAxis
     let position
-    let paddingA
-    let paddingB
     let elements
 
     // All DOM elements in the split should have a common parent. We can grab
@@ -123,18 +120,12 @@ const Split = (ids, options = {}) => {
     // rely on CSS strings and classes.
     if (direction === 'horizontal') {
         dimension = 'width'
-        clientDimension = 'clientWidth'
         clientAxis = 'clientX'
         position = 'left'
-        paddingA = 'paddingLeft'
-        paddingB = 'paddingRight'
     } else if (direction === 'vertical') {
         dimension = 'height'
-        clientDimension = 'clientHeight'
         clientAxis = 'clientY'
         position = 'top'
-        paddingA = 'paddingTop'
-        paddingB = 'paddingBottom'
     }
 
     // 3. Define the dragging helper functions, and a few helpers to go with them.
@@ -156,14 +147,18 @@ const Split = (ids, options = {}) => {
         const style = elementStyle(dimension, size, gutSize)
 
         // eslint-disable-next-line no-param-reassign
-        Object.keys(style).forEach(prop => (el.style[prop] = style[prop]))
+        Object.keys(style).forEach(prop => {
+            el.style[prop] = style[prop]
+        })
     }
 
     function setGutterSize (gutterElement, gutSize) {
         const style = gutterStyle(dimension, gutSize)
 
         // eslint-disable-next-line no-param-reassign
-        Object.keys(style).forEach(prop => (gutterElement.style[prop] = style[prop]))
+        Object.keys(style).forEach(prop => {
+            gutterElement.style[prop] = style[prop]
+        })
     }
 
     // Actually adjust the size of elements `a` and `b` to `offset` while dragging.
@@ -200,6 +195,8 @@ const Split = (ids, options = {}) => {
     // | <- this.start                                        this.size -> |
     function drag (e) {
         let offset
+        const a = elements[this.a]
+        const b = elements[this.b]
 
         if (!this.dragging) return
 
@@ -215,10 +212,10 @@ const Split = (ids, options = {}) => {
         // If within snapOffset of min or max, set offset to min or max.
         // snapOffset buffers a.minSize and b.minSize, so logic is opposite for both.
         // Include the appropriate gutter sizes to prevent overflows.
-        if (offset <= elements[this.a].minSize + snapOffset + this.aGutterSize) {
-            offset = elements[this.a].minSize + this.aGutterSize
-        } else if (offset >= this.size - (elements[this.b].minSize + snapOffset + this.bGutterSize)) {
-            offset = this.size - (elements[this.b].minSize + this.bGutterSize)
+        if (offset <= a.minSize + snapOffset + this.aGutterSize) {
+            offset = a.minSize + this.aGutterSize
+        } else if (offset >= this.size - (b.minSize + snapOffset + this.bGutterSize)) {
+            offset = this.size - (b.minSize + this.bGutterSize)
         }
 
         // Actually adjust the size.
@@ -249,8 +246,11 @@ const Split = (ids, options = {}) => {
         const a = elements[this.a].element
         const b = elements[this.b].element
 
-        this.size = a[getBoundingClientRect]()[dimension] + b[getBoundingClientRect]()[dimension] + this.aGutterSize + this.bGutterSize
-        this.start = a[getBoundingClientRect]()[position]
+        const aBounds = a[getBoundingClientRect]()
+        const bBounds = b[getBoundingClientRect]()
+
+        this.size = aBounds[dimension] + bBounds[dimension] + this.aGutterSize + this.bGutterSize
+        this.start = aBounds[position]
     }
 
     // stopDragging is very similar to startDragging in reverse.

--- a/src/split.js
+++ b/src/split.js
@@ -269,9 +269,8 @@ const Split = (ids, options = {}) => {
         global[removeEventListener]('mouseup', self.stop)
         global[removeEventListener]('touchend', self.stop)
         global[removeEventListener]('touchcancel', self.stop)
-
-        self.parent[removeEventListener]('mousemove', self.move)
-        self.parent[removeEventListener]('touchmove', self.move)
+        global[removeEventListener]('mousemove', self.move)
+        global[removeEventListener]('touchmove', self.move)
 
         // Delete them once they are removed. I think this makes a difference
         // in memory usage with a lot of splits on one page. But I don't know for sure.
@@ -295,6 +294,7 @@ const Split = (ids, options = {}) => {
 
         self.gutter.style.cursor = ''
         self.parent.style.cursor = ''
+        document.body.style.cursor = ''
     }
 
     // startDragging calls `calculateSizes` to store the inital size in the pair object.
@@ -326,9 +326,8 @@ const Split = (ids, options = {}) => {
         global[addEventListener]('mouseup', self.stop)
         global[addEventListener]('touchend', self.stop)
         global[addEventListener]('touchcancel', self.stop)
-
-        self.parent[addEventListener]('mousemove', self.move)
-        self.parent[addEventListener]('touchmove', self.move)
+        global[addEventListener]('mousemove', self.move)
+        global[addEventListener]('touchmove', self.move)
 
         // Disable selection. Disable!
         a[addEventListener]('selectstart', NOOP)
@@ -350,6 +349,7 @@ const Split = (ids, options = {}) => {
         // Doing only a, b and gutter causes flickering.
         self.gutter.style.cursor = cursor
         self.parent.style.cursor = cursor
+        document.body.style.cursor = cursor
 
         // Cache the initial sizes of the pair.
         calculateSizes.call(self)

--- a/src/split.js
+++ b/src/split.js
@@ -129,7 +129,7 @@ const Split = (ids, options = {}) => {
     }
 
     // 3. Define the dragging helper functions, and a few helpers to go with them.
-    // Each helper is bound to a pair object that contains it's metadata. This
+    // Each helper is bound to a pair object that contains its metadata. This
     // also makes it easy to store references to listeners that that will be
     // added and removed.
     //
@@ -345,8 +345,7 @@ const Split = (ids, options = {}) => {
         b.style.MozUserSelect = 'none'
         b.style.pointerEvents = 'none'
 
-        // Set the cursor, both on the gutter and the parent element.
-        // Doing only a, b and gutter causes flickering.
+        // Set the cursor at multiple levels
         self.gutter.style.cursor = cursor
         self.parent.style.cursor = cursor
         document.body.style.cursor = cursor
@@ -387,7 +386,7 @@ const Split = (ids, options = {}) => {
         let pair
 
         if (i > 0) {
-            // Create the pair object with it's metadata.
+            // Create the pair object with its metadata.
             pair = {
                 a: i - 1,
                 b: i,


### PR DESCRIPTION
Patch for https://github.com/nathancahill/Split.js/issues/111

Thanks for giving me contributor access, but to begin with I'd like to stick to PRs so you get a chance to comment.

This series of commits fixes the linter issues I mentioned, moves event listeners from the parent node to the root node, and tidies up a few minor things (slightly better minification).

Tested in Chrome, FireFox and Safari