### PR TITLE
Add ability to access parent and pairs

### DIFF
--- a/src/split.js
+++ b/src/split.js
@@ -517,6 +517,8 @@ const Split = (ids, options = {}) => {
             }
         },
         destroy,
+        parent: parent,
+        pairs: pairs
     }
 }
 


### PR DESCRIPTION
Added the ability to see the parent and the pairs associated with a particular split widget.  This will allow users to further modify the widget once the widget has been created.  

Example use case: I want to customize the grip used by the gutter element with custom HTML.  Rather than using a generic selector, I can then do something like this:

        var split = Split(["#TopPane", "#BottomPane"], { ... });

        for (var i = 0; i < split.pairs.length; i++) {
            if (split.pairs[i].direction === 'vertical') {
                $(split.pairs[i].gutter).append($("<i class='fa fa-ellipsis-h'></i>"));
            }
        }