### PR TITLE
throw an exception when the element matching to a selector was not found

### DIFF
--- a/src/split.js
+++ b/src/split.js
@@ -115,6 +115,10 @@ const Split = (ids, options = {}) => {
     // All DOM elements in the split should have a common parent. We can grab
     // the first elements parent and hope users read the docs because the
     // behavior will be whacky otherwise.
+    const firstElement = elementOrSelector(ids[0])
+    if (firstElement === null) {
+        throw new Error(`no element found matching selector ${ids[0]}`)
+    }
     const parent = elementOrSelector(ids[0]).parentNode
     const parentFlexDirection = global.getComputedStyle(parent).flexDirection
 
@@ -396,6 +400,10 @@ const Split = (ids, options = {}) => {
             element: elementOrSelector(id),
             size: sizes[i],
             minSize: minSizes[i],
+        }
+
+        if (element.element === null) {
+            throw new Error(`no element found matching selector ${id}`)
         }
 
         let pair


### PR DESCRIPTION
If someone passes a wrong selector, `document.querySelector(el)`(https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector) will return `null`, i.e. `elementOrSelector` function will also return `null`, the value of which is used directly in the line 118:
`elementOrSelector(ids[0]).parentNode`. It throws `TypeError: elementOrSelector(...) is null` exception that is not quite informative. Throwing meaningful exception is much better and informative.