### PR TITLE
Correct selector error message

### DIFF
--- a/src/split.js
+++ b/src/split.js
@@ -42,7 +42,7 @@ const elementOrSelector = el => {
     if (isString(el)) {
         const ele = document.querySelector(el)
         if (!ele) {
-            throw new Error(`Selector ${el} did match a DOM element`)
+            throw new Error(`Selector ${el} did not match a DOM element`)
         }
         return ele
     }


### PR DESCRIPTION
Error is thrown if selector did *not* match a DOM element